### PR TITLE
refactor(channel): move channel model from UE to BS

### DIFF
--- a/PyScheduler/BS_MODULE.py
+++ b/PyScheduler/BS_MODULE.py
@@ -362,9 +362,12 @@ class BaseStation:
     
     def __init__(self, x: float = 0.0, y: float = 0.0, height: float = 35.0,
                  frequency_GHz: float = 1.8, bandwidth: float = 10,
-                 global_max: int = 1048576, per_ue_max: int = 262144):
+                 global_max: int = 1048576, per_ue_max: int = 262144,
+                 ch_model_type: str = None,
+                 ch_model_params: dict = None):
         """
         Инициализация базовой станции.
+        #TODO: Перейти на фабричный паттерн реализации
         
         Args:
             x: Координата X расположения станции
@@ -390,11 +393,79 @@ class BaseStation:
         self.per_ue_max = per_ue_max
         self.ue_buffers = defaultdict(Buffer)
         self.ue_traffic_models = {}  # {ue_id: traffic_model}
+        
+        # Связь с моделью канала
+        self.ch_model_type = ch_model_type
+        self.channel_model = None
+        self.registered_ues = {}
+
+        if ch_model_type is not None:
+            self._init_channel_model(ch_model_params or {})
+
+    def _init_channel_model(self, params: dict) -> None:
+        """
+        Инициализация модели канала для базовой станции.
+        Использует ленивый импорт для избежания циклических зависимостей.
+        (от ленивого импорта можно избавиться)
+        
+        Args:
+            params: Параметры для конкретной модели канала
+                - RMa: W (ширина улицы), h (высота здания), cond_update_period
+                - UMa: cond_update_period, o2i_model
+                - UMi: cond_update_period, o2i_model
+        
+        Raises:
+            ValueError: Если указан неизвестный тип модели
+        """
+        # Ленивый импорт (избегаем циклических зависимостей)
+        #TODO: перейти на фабричный паттерн
+        from CHANNEL_MODEL import RMaModel, UMaModel, UMiModel
+        
+        if self.ch_model_type == 'RMa':
+            self.channel_model = RMaModel(
+                bs=self,
+                W=params.get('W', 20.0),
+                h=params.get('h', 5.0),
+                cond_update_period=params.get('cond_update_period', 0.0)
+            )
+        elif self.ch_model_type == 'UMa':
+            self.channel_model = UMaModel(
+                bs=self,
+                cond_update_period=params.get('cond_update_period', 0.0),
+                o2i_model=params.get('o2i_model', 'low')
+            )
+        elif self.ch_model_type == 'UMi':
+            self.channel_model = UMiModel(
+                bs=self,
+                cond_update_period=params.get('cond_update_period', 0.0),
+                o2i_model=params.get('o2i_model', 'low')
+            )
+        else:
+            raise ValueError(f"Неизвестный тип модели канала: {self.ch_model_type}")
 
     def REG_UE(self, ue: UserEquipment):
-        """Регистрация UE с переносом модели трафика"""
-        self.ue_buffers[ue.UE_ID] = Buffer(global_max=self.global_max, per_ue_max=self.per_ue_max)
+        """
+        Регистрация пользователя на базовой станции.
+        
+        Выполняет:
+        - Создание буфера для DL данных пользователя
+        - Привязку модели трафика пользователя
+        - Сохранение ссылки на объект UE (для расчета SINR)
+        - Установку обратной связи UE -> BS (для доступа к модели канала)
+        
+        Args:
+            ue: Объект UserEquipment для регистрации
+        """
+        # Существующая логика (без изменений)
+        self.ue_buffers[ue.UE_ID] = Buffer(
+            global_max=self.global_max, 
+            per_ue_max=self.per_ue_max
+        )
         self.ue_traffic_models[ue.UE_ID] = ue.traffic_model
+        self.registered_ues[ue.UE_ID] = ue
+        ue.serving_bs = self #теперь UE знает о своей BS
+        
+        #TODO: сделать метод DEREG_UE и сопутствующие изменения
         
     def SET_TRAFFIC_MODEL(self, ue: UserEquipment, model):
         """

--- a/PyScheduler/ENVIRONMENT.py
+++ b/PyScheduler/ENVIRONMENT.py
@@ -436,8 +436,8 @@ def test_scheduler_grid():
     # Шаг 1: Инициализация компонентов
     lte_grid = RES_GRID_LTE(bandwidth=10, num_frames=2)  # 1 фрейм = 10 TTI
     visualizer = LTEGridVisualizer(lte_grid)
-    bs = BaseStation(x=0, y=0, height=25.0, bandwidth=10)
-    scheduler = SchedulerInterface.create('ProportionalFair', lte_grid, bs, 
+    bs = BaseStation(x=0, y=0, height=25.0, bandwidth=10, ch_model_type='UMi')
+    scheduler = SchedulerInterface.create('RoundRobin', lte_grid, bs, 
                                           max_dl_ue_tti=5,
                                           pcfich=2,
                                           max_dl_cce_allowance=None,
@@ -459,7 +459,6 @@ def test_scheduler_grid():
     for ue in [ue1, ue2, ue3, ue4, ue5]:
         ue.SET_MOBILITY_MODEL(RandomWalkModel(x_min=0, x_max=1000, y_min=0, y_max=1000))
         ue.SET_TRAFFIC_MODEL(PoissonModel(packet_rate=5000))
-        ue.SET_CH_MODEL(UMiModel(bs))
         bs.REG_UE(ue)
         bs.ue_buffers[ue.UE_ID].ADD_PACKET(
             Packet(size=50000, ue_id=ue.UE_ID, creation_time=current_time), 

--- a/PyScheduler/UE_MODULE.py
+++ b/PyScheduler/UE_MODULE.py
@@ -327,7 +327,7 @@ class UserEquipment:
         self.traffic_model = None  # Установить позже
         
         # Параметры канала связи
-        self.channel_model = None  # Установить позже
+        self.serving_bs = None  # Установить позже
         self.cqi = 1  # Текущий CQI (1-15)
         self.SINR = 0.0  # Текущее отношение сигнал/шум+помехи в dB
         
@@ -392,20 +392,20 @@ class UserEquipment:
         # @IvanNoritsin: Нужен базовый класс для моделей передвижения для более
         # корректной валидации.
     
-    def SET_CH_MODEL(self, model) -> None:
-        """
-        Установить модель радиоканала для пользователя.
+    # def SET_CH_MODEL(self, model) -> None:
+    #     """
+    #     Установить модель радиоканала для пользователя.
 
-        Args:
-            model (ChannelModel): Модель радиоканала.
+    #     Args:
+    #         model (ChannelModel): Модель радиоканала.
 
-        """
-        from CHANNEL_MODEL import ChannelModel
+    #     """
+    #     from CHANNEL_MODEL import ChannelModel
         
-        if not isinstance(model, ChannelModel):
-            raise TypeError(f"Некорректный тип модели канала: {type(model).__name__}")
+    #     if not isinstance(model, ChannelModel):
+    #         raise TypeError(f"Некорректный тип модели канала: {type(model).__name__}")
         
-        self.channel_model = model
+    #     self.channel_model = model
     
     def SET_TRAFFIC_MODEL(self, model) -> None:
         """
@@ -481,20 +481,23 @@ class UserEquipment:
         """
         from CHANNEL_MODEL import RMaModel, UMaModel, UMiModel
         
-        if not self.channel_model:
-            raise ValueError("Ошибка! Модель канала не определена! {}".format(self.UE_ID))
+        if not self.serving_bs:
+            raise ValueError("Ошибка! UE не подключен к базовой станции! {}".format(self.UE_ID))
+        
+        if not self.serving_bs.channel_model:
+            raise ValueError("Ошибка! У базовой станции не инициализирована модель канала!")
         
         displacement = np.hypot(self.position[0] - self.coordinates[-2][0],
                                 self.position[1] - self.coordinates[-2][1])
         
-        if isinstance(self.channel_model, RMaModel):
+        if isinstance(self.serving_bs.channel_model, RMaModel):
             if self.UE_height == 0.0:
                 if self.is_indoor == True:
                     self.UE_height = np.random.uniform(1, 10)
                 else:
                     self.UE_height = 1.0
-            
-        if isinstance(self.channel_model, (UMaModel, UMiModel)):
+        
+        if isinstance(self.serving_bs.channel_model, (UMaModel, UMiModel)):
             if self.UE_height == 0.0:
                 if self.is_indoor == True:
                     N_fl = np.random.uniform(4, 8)
@@ -502,17 +505,16 @@ class UserEquipment:
                     self.UE_height = 3 * (n_fl - 1) + 1.5
                 else:
                     self.UE_height = 1.5
-                  
-        self.SINR = self.channel_model.calculate_SINR(
+        
+        self.SINR = self.serving_bs.channel_model.calculate_SINR(
             self.UE_ID, displacement, self.dist_to_BS_2D, self.dist_to_BS_2D_in, 
             self.dist_to_BS_3D, self.UE_height, self.ue_class
         )
         
         self.cqi = self.SINR_TO_CQI(self.SINR)
-                
         self.SINR_values.append(self.SINR)
         self.CQI_values.append(self.cqi)
-    
+        
     def GEN_TRFFC(self, current_time: int, update_interval: int) -> None:
         """
         Сгенерировать пакеты трафика согласно модели и добавить их в буфер.
@@ -910,25 +912,6 @@ class UECollection:
         for ue in self.users.values():
             if ue_ids is None or ue.UE_ID in ue_ids:
                 ue.SET_MOBILITY_MODEL(model)
-                
-    def SET_CH_MODEL(self, model, ue_ids: List[int] = None):
-        """
-        Установить модель радиоканала для пользователей в коллекции. Если ue_ids
-        задан как None, то модель применится ко всем UE в коллекции. 
-
-        Args:
-            model (ChannelModel): Модель радиоканала.
-            ue_ids (List[int], optional): Список ID пользователей, к которым
-            необходимо применить модель. По умолчанию None.
-
-        """
-        for ue in self.users.values():
-            if ue_ids is None or ue.UE_ID in ue_ids:
-                ue.SET_CH_MODEL(model)
-                
-        # @IvanNoritsin: Пока что у нас модель трафика задаётся для каждого
-        # пользователя, а не для БС. Как только данный момент будет исправлен,
-        # надобность в этой функции исчезнет и её нужно будет удалить.
                
     def SET_TRAFFIC_MODEL(self, model, ue_ids: List[int] = None):
         """


### PR DESCRIPTION
Привязка вызова моделей канала через BS а не через UE

Модель канала теперь принадлежит BaseStation, а не UserEquipment.
Это подготавливает проект к реализации HARQ, проработанной процедуры регистрации/дерегистрации, а также хэндовера между базовыми станциями.

Изменения в BS_MODULE.py:
- Добавлены параметры ch_model_type и ch_model_params в __init__
- Реализован метод _init_channel_model с ленивым импортом (перейти на Factory pattern в будущем)
- Расширен REG_UE для установки двусторонней связи BS ↔ UE
- Добавлен атрибут registered_ues для хранения ссылок на UE. Теперь BS знает своих абонентов, а абоненты - BS.

Изменения в UE_MODULE.py:
- Заменен self.channel_model на self.serving_bs
- Переписан UPD_CH_QUALITY для использования serving_bs.channel_model
- Удалены методы SET_CH_MODEL из UserEquipment и UECollection

Преимущества:
- Централизация: вся инициализация модели в конструкторе BS
- Готовность к масштабированию: поддержка множественных BS
- Упрощение для хэндовера: UE будет менять serving_bs при переходе

Breaking Changes:
- Удален метод UserEquipment.SET_CH_MODEL()
- Удален метод UECollection.SET_CH_MODEL()
- Код симуляции требует обновления (см. документацию)

Выделены некоторые задачи для дальнейшей оптимизации